### PR TITLE
Add missing C++ include

### DIFF
--- a/include/nesoi/search-functors.h
+++ b/include/nesoi/search-functors.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <limits>
 
 namespace nesoi
 {


### PR DESCRIPTION
Add missing include of `limits.h` in `include/nesoi/search-functors.h`